### PR TITLE
Implement tile wall and initial hand distribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,15 @@ This document describes the layout and conventions used in this repository. Alwa
 ## Development Notes
 - This repository tracks phased development. Commit messages should be descriptive and prefixed with the phase, e.g., `PH1-01: Create Tile model`.
 - Keep this file up to date if the project structure changes.
+
+## Tile Wall Logic
+- The `GameState` view model is responsible for creating and shuffling the full wall of 136 tiles. Use `shuffleWall()` to populate the wall array.
+- Initial hand distribution for the four players occurs in `dealInitialHands()` within the same file.
+
+## Player Model
+- Located at `Mahjong4/Models/Player.swift`.
+- Contains `id` (0–3) and `hand` (array of `Tile`).
+
+## Sorting Convention
+- Tile sorting is implemented in `Utilities/TileHelpers.swift`.
+- Hands are sorted by suit in the order: Bamboo, Character, Dot, Winds (East–North), Dragons (Red–White), Flowers, Seasons, and then by numeric value within each group.

--- a/Mahjong4/Models/Player.swift
+++ b/Mahjong4/Models/Player.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Represents a player in the game.
+struct Player: Identifiable {
+    let id: Int            // 0-3
+    var hand: [Tile] = []  // 13 tiles dealt at start
+}
+

--- a/Mahjong4/Utilities/TileHelpers.swift
+++ b/Mahjong4/Utilities/TileHelpers.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Helper methods for working with tiles.
+enum TileHelpers {
+    /// Sort tiles primarily by suit/honor and then by their numeric value.
+    static func sortTiles(_ tiles: [Tile]) -> [Tile] {
+        return tiles.sorted { lhs, rhs in
+            orderValue(for: lhs) < orderValue(for: rhs)
+        }
+    }
+
+    /// Provides a sortable integer for a tile.
+    private static func orderValue(for tile: Tile) -> Int {
+        switch tile {
+        case .bamboo(let value):
+            return 0 * 10 + value
+        case .character(let value):
+            return 1 * 10 + value
+        case .dot(let value):
+            return 2 * 10 + value
+        case .wind(let wind):
+            // East, South, West, North
+            let index = Tile.Wind.allCases.firstIndex(of: wind) ?? 0
+            return 3 * 10 + index
+        case .dragon(let dragon):
+            // Red, Green, White
+            let index = Tile.Dragon.allCases.firstIndex(of: dragon) ?? 0
+            return 4 * 10 + index
+        case .flower(let value):
+            return 5 * 10 + value
+        case .season(let value):
+            return 6 * 10 + value
+        }
+    }
+}

--- a/Mahjong4/ViewModels/GameState.swift
+++ b/Mahjong4/ViewModels/GameState.swift
@@ -1,7 +1,67 @@
 import Foundation
 
-/// Placeholder for game state management.
-/// Responsible for tracking players, hands, and wall state.
+/// Manages game state including players and the tile wall.
 class GameState: ObservableObject {
-    // TODO: Implement player states and wall tiles
+    /// The complete wall of tiles. Tiles are removed from here as they are dealt.
+    @Published private(set) var wall: [Tile] = []
+
+    /// Four players participating in the game.
+    @Published private(set) var players: [Player] = (0..<4).map { Player(id: $0) }
+
+    /// Creates and shuffles the full wall of 136 tiles.
+    func shuffleWall() {
+        var tiles: [Tile] = []
+
+        // Suited tiles: 1-9 of each suit with four copies each
+        for value in 1...9 {
+            for _ in 0..<4 {
+                tiles.append(.bamboo(value))
+                tiles.append(.character(value))
+                tiles.append(.dot(value))
+            }
+        }
+
+        // Winds and dragons: four copies each
+        for wind in Tile.Wind.allCases {
+            for _ in 0..<4 {
+                tiles.append(.wind(wind))
+            }
+        }
+
+        for dragon in Tile.Dragon.allCases {
+            for _ in 0..<4 {
+                tiles.append(.dragon(dragon))
+            }
+        }
+
+        // Flowers and seasons: one copy each
+        for value in 1...4 {
+            tiles.append(.flower(value))
+            tiles.append(.season(value))
+        }
+
+        tiles.shuffle()
+        wall = tiles
+    }
+
+    /// Deals 13 tiles to each player from the wall.
+    func dealInitialHands() {
+        // Ensure the wall is shuffled and full
+        guard wall.count >= 16 * 4 + 8 else { return }
+
+        for index in players.indices {
+            var hand: [Tile] = []
+            for _ in 0..<13 {
+                if let tile = wall.first {
+                    hand.append(tile)
+                    wall.removeFirst()
+                }
+            }
+            hand = TileHelpers.sortTiles(hand)
+            players[index].hand = hand
+            print("Player \(players[index].id) hand: \(hand)")
+        }
+
+        print("Remaining tiles in wall: \(wall.count)")
+    }
 }

--- a/Mahjong4/Views/MainView.swift
+++ b/Mahjong4/Views/MainView.swift
@@ -1,10 +1,16 @@
 import SwiftUI
 
 struct MainView: View {
+    @StateObject private var gameState = GameState()
+
     var body: some View {
         Text("Mahjong4")
             .font(.largeTitle)
             .padding()
+            .onAppear {
+                gameState.shuffleWall()
+                gameState.dealInitialHands()
+            }
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -26,3 +26,6 @@ Mahjong4/
 3. **Phase 3 – Networking**: Add multiplayer and networking capabilities.
 
 Updates to this plan will occur as development progresses.
+
+## Tile Wall and Initial Hands
+The game state builds a complete wall of 136 tiles which is shuffled at the start of a session. Each of the four players is then dealt 13 tiles from the top of this wall. The hands are sorted for readability using helpers in `Utilities/TileHelpers.swift`.


### PR DESCRIPTION
## Summary
- implement GameState logic for the shuffled wall and initial hands
- create Player model and tile sorting helpers
- trigger shuffle/deal on app launch for debug output
- document wall logic and update agents guidelines

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686ccd4181108328b5cc78cc05a9199a