### PR TITLE
Implement TileView and hand rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,8 @@ This document describes the layout and conventions used in this repository. Alwa
 ## Sorting Convention
 - Tile sorting is implemented in `Utilities/TileHelpers.swift`.
 - Hands are sorted by suit in the order: Bamboo, Character, Dot, Winds (East–North), Dragons (Red–White), Flowers, Seasons, and then by numeric value within each group.
+
+## UI Components
+- `TileView` and `TileRowView` are located in `Mahjong4/Views/`.
+- Name view files using the pattern `NameView.swift` (PascalCase) and keep SwiftUI code free of game logic.
+- Views are fed data from view models; they should not modify `GameState` directly.

--- a/Mahjong4/Utilities/TileDisplay.swift
+++ b/Mahjong4/Utilities/TileDisplay.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension Tile {
+    /// Placeholder text representation of a tile for early UI prototyping.
+    var displayString: String {
+        switch self {
+        case .bamboo(let value):
+            return "Bamboo \(value)"
+        case .character(let value):
+            return "Character \(value)"
+        case .dot(let value):
+            return "Dot \(value)"
+        case .wind(let wind):
+            return wind.rawValue.capitalized + " Wind"
+        case .dragon(let dragon):
+            return dragon.rawValue.capitalized + " Dragon"
+        case .flower(let value):
+            return "Flower \(value)"
+        case .season(let value):
+            return "Season \(value)"
+        }
+    }
+}

--- a/Mahjong4/Views/MainView.swift
+++ b/Mahjong4/Views/MainView.swift
@@ -4,13 +4,20 @@ struct MainView: View {
     @StateObject private var gameState = GameState()
 
     var body: some View {
-        Text("Mahjong4")
-            .font(.largeTitle)
-            .padding()
-            .onAppear {
-                gameState.shuffleWall()
-                gameState.dealInitialHands()
-            }
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Mahjong4")
+                .font(.largeTitle)
+
+            Text("Player 1 Hand")
+                .font(.headline)
+
+            TileRowView(tiles: gameState.players.first?.hand ?? [])
+        }
+        .padding()
+        .onAppear {
+            gameState.shuffleWall()
+            gameState.dealInitialHands()
+        }
     }
 }
 

--- a/Mahjong4/Views/TileRowView.swift
+++ b/Mahjong4/Views/TileRowView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Displays a horizontal scrollable row of tiles.
+struct TileRowView: View {
+    let tiles: [Tile]
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 4) {
+                ForEach(Array(tiles.enumerated()), id: \".offset\") { _, tile in
+                    TileView(tile: tile)
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+}
+
+struct TileRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        TileRowView(tiles: [
+            .bamboo(1), .character(2), .dot(3), .wind(.east), .dragon(.red)
+        ])
+    }
+}

--- a/Mahjong4/Views/TileView.swift
+++ b/Mahjong4/Views/TileView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Displays a single Mahjong tile using placeholder text.
+struct TileView: View {
+    let tile: Tile
+    var body: some View {
+        Text(tile.displayString)
+            .font(.caption)
+            .frame(width: 40, height: 60)
+            .background(Color.white)
+            .cornerRadius(4)
+            .shadow(radius: 1)
+    }
+}
+
+struct TileView_Previews: PreviewProvider {
+    static var previews: some View {
+        TileView(tile: .bamboo(1))
+            .previewLayout(.sizeThatFits)
+            .padding()
+            .background(Color.gray.opacity(0.2))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ Updates to this plan will occur as development progresses.
 
 ## Tile Wall and Initial Hands
 The game state builds a complete wall of 136 tiles which is shuffled at the start of a session. Each of the four players is then dealt 13 tiles from the top of this wall. The hands are sorted for readability using helpers in `Utilities/TileHelpers.swift`.
+
+## Player Hand Display (Phase 1)
+The first visual component renders a player's 13-tile hand. `TileView` shows a single tile using placeholder text while `TileRowView` arranges an array of tiles in a horizontal scrollable row. `MainView` now displays Player 1's hand using these views.


### PR DESCRIPTION
## Summary
- add placeholder display string for `Tile`
- show a single tile via `TileView`
- arrange tiles in a horizontal `TileRowView`
- render player 1's hand in `MainView`
- document hand display in README
- update AGENTS notes about new views

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_686ccf345fc8832882ed8c8154326cd5