### PR TITLE
Enable draw/discard loop for Player 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ This document describes the layout and conventions used in this repository. Alwa
 - The `GameState` view model is responsible for creating and shuffling the full wall of 136 tiles. Use `shuffleWall()` to populate the wall array.
 - Initial hand distribution for the four players occurs in `dealInitialHands()` within the same file.
 
+### Draw & Discard
+- `GameState` owns the `drawTile(for:)` and `discardTile(_:for:)` methods. These modify a player's hand, update the discard pile, and toggle a `hasDrawnThisTurn` flag.
+- `TileView` supports an optional `onTap` closure so views like `TileRowView` can forward tap events for discarding.
+
 ## Player Model
 - Located at `Mahjong4/Models/Player.swift`.
 - Contains `id` (0–3) and `hand` (array of `Tile`).

--- a/Mahjong4/ViewModels/GameState.swift
+++ b/Mahjong4/ViewModels/GameState.swift
@@ -8,6 +8,12 @@ class GameState: ObservableObject {
     /// Four players participating in the game.
     @Published private(set) var players: [Player] = (0..<4).map { Player(id: $0) }
 
+    /// Tiles discarded by Player 1.
+    @Published private(set) var discardPile: [Tile] = []
+
+    /// Indicates if Player 1 has already drawn this turn.
+    @Published var hasDrawnThisTurn: Bool = false
+
     /// Creates and shuffles the full wall of 136 tiles.
     func shuffleWall() {
         var tiles: [Tile] = []
@@ -63,5 +69,33 @@ class GameState: ObservableObject {
         }
 
         print("Remaining tiles in wall: \(wall.count)")
+    }
+
+    /// Resets state for a new game session.
+    func startNewGame() {
+        shuffleWall()
+        dealInitialHands()
+        discardPile = []
+        hasDrawnThisTurn = false
+    }
+
+    /// Draws a single tile for the provided player.
+    func drawTile(for player: Player) {
+        guard let index = players.firstIndex(where: { $0.id == player.id }) else { return }
+        guard !hasDrawnThisTurn, players[index].hand.count < 14, let tile = wall.first else { return }
+
+        players[index].hand.append(tile)
+        wall.removeFirst()
+        hasDrawnThisTurn = true
+    }
+
+    /// Discards the specified tile from the player's hand.
+    func discardTile(_ tile: Tile, for player: Player) {
+        guard let index = players.firstIndex(where: { $0.id == player.id }) else { return }
+        guard hasDrawnThisTurn, let removeIndex = players[index].hand.firstIndex(of: tile) else { return }
+
+        players[index].hand.remove(at: removeIndex)
+        discardPile.append(tile)
+        hasDrawnThisTurn = false
     }
 }

--- a/Mahjong4/Views/DiscardPileView.swift
+++ b/Mahjong4/Views/DiscardPileView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Displays the tiles discarded by Player 1.
+struct DiscardPileView: View {
+    let tiles: [Tile]
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Discards")
+                .font(.headline)
+            TileRowView(tiles: tiles)
+        }
+    }
+}
+
+struct DiscardPileView_Previews: PreviewProvider {
+    static var previews: some View {
+        DiscardPileView(tiles: [.bamboo(1), .character(2)])
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Mahjong4/Views/MainView.swift
+++ b/Mahjong4/Views/MainView.swift
@@ -8,15 +8,32 @@ struct MainView: View {
             Text("Mahjong4")
                 .font(.largeTitle)
 
+            Button("Draw Tile") {
+                if let player = gameState.players.first {
+                    gameState.drawTile(for: player)
+                }
+            }
+            .disabled(gameState.hasDrawnThisTurn || (gameState.players.first?.hand.count ?? 0) >= 14)
+
             Text("Player 1 Hand")
                 .font(.headline)
 
-            TileRowView(tiles: gameState.players.first?.hand ?? [])
+            TileRowView(
+                tiles: gameState.players.first?.hand ?? [],
+                onTileTap: { tile in
+                    if let player = gameState.players.first {
+                        gameState.discardTile(tile, for: player)
+                    }
+                }
+            )
+
+            if !gameState.discardPile.isEmpty {
+                DiscardPileView(tiles: gameState.discardPile)
+            }
         }
         .padding()
         .onAppear {
-            gameState.shuffleWall()
-            gameState.dealInitialHands()
+            gameState.startNewGame()
         }
     }
 }

--- a/Mahjong4/Views/TileRowView.swift
+++ b/Mahjong4/Views/TileRowView.swift
@@ -3,11 +3,12 @@ import SwiftUI
 /// Displays a horizontal scrollable row of tiles.
 struct TileRowView: View {
     let tiles: [Tile]
+    var onTileTap: ((Tile) -> Void)? = nil
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 4) {
                 ForEach(Array(tiles.enumerated()), id: \".offset\") { _, tile in
-                    TileView(tile: tile)
+                    TileView(tile: tile, onTap: { onTileTap?(tile) })
                 }
             }
             .padding(.horizontal)

--- a/Mahjong4/Views/TileView.swift
+++ b/Mahjong4/Views/TileView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// Displays a single Mahjong tile using placeholder text.
 struct TileView: View {
     let tile: Tile
+    var onTap: (() -> Void)? = nil
+
     var body: some View {
         Text(tile.displayString)
             .font(.caption)
@@ -10,6 +12,9 @@ struct TileView: View {
             .background(Color.white)
             .cornerRadius(4)
             .shadow(radius: 1)
+            .onTapGesture {
+                onTap?()
+            }
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ The game state builds a complete wall of 136 tiles which is shuffled at the star
 
 ## Player Hand Display (Phase 1)
 The first visual component renders a player's 13-tile hand. `TileView` shows a single tile using placeholder text while `TileRowView` arranges an array of tiles in a horizontal scrollable row. `MainView` now displays Player 1's hand using these views.
+
+### Draw and Discard Interaction
+Player 1 can tap **Draw Tile** to take a tile from the wall. Once a fourteenth tile is in hand, tapping any tile discards it to a simple pile and re-enables the draw button. This loop mimics the real Mahjong flow of draw then discard.


### PR DESCRIPTION
## Summary
- allow GameState to track discards and drawing
- handle draw/discard interactions in MainView
- support tile tapping in TileView/TileRowView
- show discarded tiles in new DiscardPileView
- document interaction loop
- update AGENTS guidelines

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686cd3e8f6c883288e28595f51624487