### PR TITLE
Implement automatic hand sorting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,10 @@ This document describes the layout and conventions used in this repository. Alwa
 - Contains `id` (0–3) and `hand` (array of `Tile`).
 
 ## Sorting Convention
-- Tile sorting is implemented in `Utilities/TileHelpers.swift`.
-- Hands are sorted by suit in the order: Bamboo, Character, Dot, Winds (East–North), Dragons (Red–White), Flowers, Seasons, and then by numeric value within each group.
+- Sorting helpers live in `Utilities/TileHelpers.swift`.
+- Use `sortHand(_:)` to arrange any array of tiles.
+- Tiles are ordered Characters → Bamboo → Dots → Winds (East–North) → Dragons (Red–White) → Flowers → Seasons with numeric order within each group.
+- Hands are sorted after the initial deal, after each draw, and after each discard. Do not implement custom sorting in views or other view models; always use the helper.
 
 ## UI Components
 - `TileView` and `TileRowView` are located in `Mahjong4/Views/`.

--- a/Mahjong4/Utilities/TileHelpers.swift
+++ b/Mahjong4/Utilities/TileHelpers.swift
@@ -4,8 +4,13 @@ import Foundation
 enum TileHelpers {
     /// Sort tiles primarily by suit/honor and then by their numeric value.
     static func sortTiles(_ tiles: [Tile]) -> [Tile] {
+        return sortHand(tiles)
+    }
+
+    /// Sort a player's hand using the standard suit priority.
+    static func sortHand(_ tiles: [Tile]) -> [Tile] {
         return tiles.sorted { lhs, rhs in
-            orderValue(for: lhs) < orderValue(for: rhs)
+            handOrderValue(for: lhs) < handOrderValue(for: rhs)
         }
     }
 
@@ -30,6 +35,48 @@ enum TileHelpers {
             return 5 * 10 + value
         case .season(let value):
             return 6 * 10 + value
+        }
+    }
+
+    /// Provides ordering for `sortHand` using Character → Bamboo → Dot → Winds → Dragons.
+    private static func handOrderValue(for tile: Tile) -> Int {
+        switch tile {
+        case .character(let value):
+            return 0 * 10 + value
+        case .bamboo(let value):
+            return 1 * 10 + value
+        case .dot(let value):
+            return 2 * 10 + value
+        case .wind(let wind):
+            let index = Tile.Wind.allCases.firstIndex(of: wind) ?? 0
+            return 3 * 10 + index
+        case .dragon(let dragon):
+            let index = Tile.Dragon.allCases.firstIndex(of: dragon) ?? 0
+            return 4 * 10 + index
+        case .flower(let value):
+            return 5 * 10 + value
+        case .season(let value):
+            return 6 * 10 + value
+        }
+    }
+
+    /// Returns an integer group value for suit boundaries used in views.
+    static func suitGroup(for tile: Tile) -> Int {
+        switch tile {
+        case .character:
+            return 0
+        case .bamboo:
+            return 1
+        case .dot:
+            return 2
+        case .wind:
+            return 3
+        case .dragon:
+            return 4
+        case .flower:
+            return 5
+        case .season:
+            return 6
         }
     }
 }

--- a/Mahjong4/ViewModels/GameState.swift
+++ b/Mahjong4/ViewModels/GameState.swift
@@ -68,7 +68,7 @@ class GameState: ObservableObject {
                     wall.removeFirst()
                 }
             }
-            hand = TileHelpers.sortTiles(hand)
+            hand = TileHelpers.sortHand(hand)
             players[index].hand = hand
             print("Player \(players[index].id) hand: \(hand)")
         }
@@ -95,7 +95,7 @@ class GameState: ObservableObject {
 
         players[index].hand.append(tile)
         wall.removeFirst()
-        players[index].hand = TileHelpers.sortTiles(players[index].hand)
+        players[index].hand = TileHelpers.sortHand(players[index].hand)
         hasDrawnThisTurn = true
 
         if HandValidator.isWinningHand(players[index].hand) {
@@ -113,7 +113,7 @@ class GameState: ObservableObject {
 
         players[index].hand.remove(at: removeIndex)
         discardPile.append(tile)
-        players[index].hand = TileHelpers.sortTiles(players[index].hand)
+        players[index].hand = TileHelpers.sortHand(players[index].hand)
         hasDrawnThisTurn = false
         advanceTurn()
     }

--- a/Mahjong4/Views/TileRowView.swift
+++ b/Mahjong4/Views/TileRowView.swift
@@ -7,8 +7,15 @@ struct TileRowView: View {
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 4) {
-                ForEach(Array(tiles.enumerated()), id: \".offset\") { _, tile in
+                ForEach(Array(tiles.enumerated()), id: \".offset\") { index, tile in
                     TileView(tile: tile, onTap: { onTileTap?(tile) })
+                    if index < tiles.count - 1 {
+                        let current = TileHelpers.suitGroup(for: tile)
+                        let next = TileHelpers.suitGroup(for: tiles[index + 1])
+                        if current != next {
+                            Color.clear.frame(width: 8)
+                        }
+                    }
                 }
             }
             .padding(.horizontal)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Mahjong4/
 Updates to this plan will occur as development progresses.
 
 ## Tile Wall and Initial Hands
-The game state builds a complete wall of 136 tiles which is shuffled at the start of a session. Each of the four players is then dealt 13 tiles from the top of this wall. The hands are sorted for readability using helpers in `Utilities/TileHelpers.swift`.
+The game state builds a complete wall of 136 tiles which is shuffled at the start of a session. Each player is dealt 13 tiles from the top of this wall. Hands are automatically arranged using `TileHelpers.sortHand` after dealing and whenever tiles are drawn or discarded.
 
 ## Player Hand Display (Phase 1)
 The first visual component renders a player's 13-tile hand. `TileView` shows a single tile using placeholder text while `TileRowView` arranges an array of tiles in a horizontal scrollable row. `MainView` now displays each player's hand using these views.


### PR DESCRIPTION
## Summary
- add `sortHand` helper and suit group accessor
- sort hands after dealing, drawing and discarding
- space suits slightly in `TileRowView`
- document sorting helper and update README

## Testing
- `swiftc -emit-library -o /tmp/testlib.so $(find Mahjong4 -name "*.swift")` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686cf807fb3483289cd68018af117498