### PR TITLE
Implement new game reset functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,4 +51,9 @@ This document describes the layout and conventions used in this repository. Alwa
 ### Win Validation
 - `Services/HandValidator.swift` contains `isWinningHand(_:)` which checks for four melds plus a pair.
 - After `drawTile(for:)` adds a fourteenth tile, the validator runs. If it returns `true`, `winningPlayer` is set on `GameState`.
-- When `winningPlayer` is non-nil the game freezes: draw, discard and turn advancement calls exit early until `startNewGame()` resets state.
+- When `winningPlayer` is non-nil the game freezes: draw, discard and turn advancement calls exit early until `resetGame()` resets state.
+
+### Game Reset
+- `GameState.resetGame()` (ViewModels/GameState.swift) clears all hands and discards, shuffles a new wall, deals fresh hands and resets `currentTurn` and `winningPlayer`.
+- The UI should show a "New Game" button only after a win and call this method on tap.
+- Each reset starts a stateless new round; no previous game data is kept.

--- a/Mahjong4/ViewModels/GameState.swift
+++ b/Mahjong4/ViewModels/GameState.swift
@@ -86,6 +86,17 @@ class GameState: ObservableObject {
         winningPlayer = nil
     }
 
+    /// Clears all state and starts a completely fresh round.
+    func resetGame() {
+        players = (0..<4).map { Player(id: $0) }
+        currentTurn = 0
+        discardPile = []
+        hasDrawnThisTurn = false
+        winningPlayer = nil
+        shuffleWall()
+        dealInitialHands()
+    }
+
     /// Draws a single tile for the provided player.
     func drawTile(for player: Player) {
         guard winningPlayer == nil else { return }

--- a/Mahjong4/Views/MainView.swift
+++ b/Mahjong4/Views/MainView.swift
@@ -21,6 +21,9 @@ struct MainView: View {
                 Text("\u{1F389} Player \(winner + 1) wins!")
                     .font(.title)
                     .foregroundColor(.green)
+                Button("New Game") {
+                    gameState.resetGame()
+                }
             }
 
             Text("Current Turn: Player \(gameState.currentTurn + 1)")
@@ -66,7 +69,7 @@ struct MainView: View {
         }
         .padding()
         .onAppear {
-            gameState.startNewGame()
+            gameState.resetGame()
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,3 +41,6 @@ A simple turn manager now rotates play between all four participants in clockwis
 
 ### Win Detection
 After each draw the hand is checked for a basic Mahjong win consisting of four melds and one pair. The logic lives in `Services/HandValidator.swift`. When a player draws a winning tile the game state sets `winningPlayer` and further turns are disabled. `MainView` displays a congratulatory message to indicate the winner.
+
+### New Game Reset
+When a win occurs a **New Game** button appears. Tapping it calls `GameState.resetGame()` which clears all hands and discards, reshuffles the wall, deals fresh hands, and resets the turn to Player 1. No state from the previous round is preserved.


### PR DESCRIPTION
## Summary
- allow user to start a fresh round
- display a "New Game" button when the game is won
- document reset flow
- explain new reset flow in repo guidance

## Testing
- `swift --version`
- `swiftc Mahjong4/... MainView.swift -o /tmp/MahjongApp` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686cfae5e2548328a41eaeba6f763e5a